### PR TITLE
[#151322324] Implement the TLSPort and ServerCertDomainSAN

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,7 @@ type RouteSchema struct {
 	RouteServiceUrl      string             `yaml:"route_service_url"`
 	RegistrationInterval string             `yaml:"registration_interval,omitempty"`
 	HealthCheck          *HealthCheckSchema `yaml:"health_check,omitempty"`
+	ServerCertDomainSAN  string             `yaml:"server_cert_domain_san,omitempty"`
 }
 
 type MessageBusServer struct {
@@ -68,6 +69,7 @@ type Route struct {
 	RouteServiceUrl      string
 	RegistrationInterval time.Duration
 	HealthCheck          *HealthCheck
+	ServerCertDomainSAN  string
 }
 
 func NewConfigSchemaFromFile(configFile string) (ConfigSchema, error) {
@@ -206,6 +208,7 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 		Tags:                 r.Tags,
 		URIs:                 r.URIs,
 		RouteServiceUrl:      r.RouteServiceUrl,
+		ServerCertDomainSAN:  r.ServerCertDomainSAN,
 		RegistrationInterval: registrationInterval,
 		HealthCheck:          healthCheck,
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type ConfigSchema struct {
 type RouteSchema struct {
 	Name                 string             `yaml:"name"`
 	Port                 *int               `yaml:"port"`
+	TLSPort              *int               `yaml:"tls_port"`
 	Tags                 map[string]string  `yaml:"tags"`
 	URIs                 []string           `yaml:"uris"`
 	RouteServiceUrl      string             `yaml:"route_service_url"`
@@ -60,7 +61,8 @@ type Config struct {
 
 type Route struct {
 	Name                 string
-	Port                 int
+	Port                 *int
+	TLSPort              *int
 	Tags                 map[string]string
 	URIs                 []string
 	RouteServiceUrl      string
@@ -154,10 +156,14 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 		errors.Add(fmt.Errorf("no name"))
 	}
 
-	if r.Port == nil {
+	if r.Port == nil && r.TLSPort == nil {
 		errors.Add(fmt.Errorf("no port"))
-	} else if *r.Port <= 0 {
+	}
+	if r.Port != nil && *r.Port <= 0 {
 		errors.Add(fmt.Errorf("invalid port: %d", *r.Port))
+	}
+	if r.TLSPort != nil && *r.TLSPort <= 0 {
+		errors.Add(fmt.Errorf("invalid tls_port: %d", *r.TLSPort))
 	}
 
 	if len(r.URIs) == 0 {
@@ -195,7 +201,8 @@ func routeFromSchema(r RouteSchema, index int) (*Route, error) {
 
 	route := Route{
 		Name:                 r.Name,
-		Port:                 *r.Port,
+		Port:                 r.Port,
+		TLSPort:              r.TLSPort,
 		Tags:                 r.Tags,
 		URIs:                 r.URIs,
 		RouteServiceUrl:      r.RouteServiceUrl,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Config", func() {
 					TLSPort:              &port1,
 					RegistrationInterval: registrationInterval1String,
 					URIs:                 []string{"my-other-app.my-domain.com"},
+					ServerCertDomainSAN:  "my.internal.cert",
 				},
 				{
 					Name:                 routeName2,
@@ -77,6 +78,7 @@ var _ = Describe("Config", func() {
 					TLSPort:              &port1,
 					RegistrationInterval: registrationInterval1String,
 					URIs:                 []string{"my-other-app.my-domain.com"},
+					ServerCertDomainSAN:  "my.internal.cert",
 				},
 			},
 			Host: "127.0.0.1",
@@ -157,6 +159,7 @@ var _ = Describe("Config", func() {
 						TLSPort:              &port1,
 						RegistrationInterval: registrationInterval1,
 						URIs:                 configSchema.Routes[1].URIs,
+						ServerCertDomainSAN:  "my.internal.cert",
 					},
 					{
 						Name:                 routeName2,
@@ -164,6 +167,7 @@ var _ = Describe("Config", func() {
 						TLSPort:              &port1,
 						RegistrationInterval: registrationInterval1,
 						URIs:                 configSchema.Routes[1].URIs,
+						ServerCertDomainSAN:  "my.internal.cert",
 					},
 				},
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,7 +65,14 @@ var _ = Describe("Config", func() {
 				},
 				{
 					Name:                 routeName1,
-					Port:                 &port1,
+					TLSPort:              &port1,
+					RegistrationInterval: registrationInterval1String,
+					URIs:                 []string{"my-other-app.my-domain.com"},
+				},
+				{
+					Name:                 routeName1,
+					Port:                 &port0,
+					TLSPort:              &port1,
 					RegistrationInterval: registrationInterval1String,
 					URIs:                 []string{"my-other-app.my-domain.com"},
 				},
@@ -344,6 +351,19 @@ var _ = Describe("Config", func() {
 					Expect(c).To(BeNil())
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(`route "route-0"`))
+					Expect(err.Error()).To(ContainSubstring("no port"))
+				})
+			})
+			Context("when the port value is not provided", func() {
+				BeforeEach(func() {
+					configSchema.Routes[1].TLSPort = nil
+				})
+
+				It("returns an error", func() {
+					c, err := configSchema.ToConfig()
+					Expect(c).To(BeNil())
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(`route "route-1"`))
 					Expect(err.Error()).To(ContainSubstring("no port"))
 				})
 			})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Config", func() {
 
 		routeName0 string
 		routeName1 string
+		routeName2 string
 
 		port0 int
 		port1 int
@@ -39,6 +40,7 @@ var _ = Describe("Config", func() {
 
 		routeName0 = "route-0"
 		routeName1 = "route-1"
+		routeName2 = "route-2"
 
 		port0 = 3000
 		port1 = 3001
@@ -70,7 +72,7 @@ var _ = Describe("Config", func() {
 					URIs:                 []string{"my-other-app.my-domain.com"},
 				},
 				{
-					Name:                 routeName1,
+					Name:                 routeName2,
 					Port:                 &port0,
 					TLSPort:              &port1,
 					RegistrationInterval: registrationInterval1String,
@@ -146,13 +148,20 @@ var _ = Describe("Config", func() {
 				Routes: []config.Route{
 					{
 						Name:                 routeName0,
-						Port:                 port0,
+						Port:                 &port0,
 						RegistrationInterval: registrationInterval0,
 						URIs:                 configSchema.Routes[0].URIs,
 					},
 					{
 						Name:                 routeName1,
-						Port:                 port1,
+						TLSPort:              &port1,
+						RegistrationInterval: registrationInterval1,
+						URIs:                 configSchema.Routes[1].URIs,
+					},
+					{
+						Name:                 routeName2,
+						Port:                 &port0,
+						TLSPort:              &port1,
 						RegistrationInterval: registrationInterval1,
 						URIs:                 configSchema.Routes[1].URIs,
 					},

--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -9,11 +9,13 @@ routes:
   tls_port: 3001
   uris: ["my-other-app.my-domain.com"]
   registration_interval: 10s
+  server_cert_domain_san: "my.internal.cert"
 - name: "route-2"
   port: 3000
   tls_port: 3001
   uris: ["my-other-app.my-domain.com"]
   registration_interval: 10s
+  server_cert_domain_san: "my.internal.cert"
 message_bus_servers:
 - host: "some-host"
   user: "some-user"

--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -6,7 +6,12 @@ routes:
   uris: ["my-app.my-domain.com"]
   registration_interval: 20s
 - name: "route-1"
-  port: 3001
+  tls_port: 3001
+  uris: ["my-other-app.my-domain.com"]
+  registration_interval: 10s
+- name: "route-2"
+  port: 3000
+  tls_port: 3001
   uris: ["my-other-app.my-domain.com"]
   registration_interval: 10s
 message_bus_servers:

--- a/main_test.go
+++ b/main_test.go
@@ -122,10 +122,11 @@ var _ = Describe("Main", func() {
 		var receivedMessage string
 		Eventually(registered, 10*time.Second).Should(Receive(&receivedMessage))
 
+		i12345 := 12345
 		expectedRegistryMessage := messagebus.Message{
 			URIs: []string{"uri-1", "uri-2"},
 			Host: "127.0.0.1",
-			Port: 12345,
+			Port: &i12345,
 			Tags: map[string]string{"tag1": "val1", "tag2": "val2"},
 		}
 

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -28,13 +28,14 @@ type msgBus struct {
 }
 
 type Message struct {
-	URIs              []string          `json:"uris"`
-	Host              string            `json:"host"`
-	Port              *int              `json:"port,omitempty"`
-	TLSPort           *int              `json:"tls_port,omitempty"`
-	Tags              map[string]string `json:"tags"`
-	RouteServiceUrl   string            `json:"route_service_url,omitempty"`
-	PrivateInstanceId string            `json:"private_instance_id"`
+	URIs                []string          `json:"uris"`
+	Host                string            `json:"host"`
+	Port                *int              `json:"port,omitempty"`
+	TLSPort             *int              `json:"tls_port,omitempty"`
+	Tags                map[string]string `json:"tags"`
+	RouteServiceUrl     string            `json:"route_service_url,omitempty"`
+	PrivateInstanceId   string            `json:"private_instance_id"`
+	ServerCertDomainSAN string            `json:"server_cert_domain_san,omitempty"`
 }
 
 func NewMessageBus(logger lager.Logger) MessageBus {
@@ -99,13 +100,14 @@ func (m msgBus) SendMessage(subject string, host string, route config.Route, pri
 	m.logger.Debug("creating-message", lager.Data{"subject": subject, "host": host, "route": route, "privateInstanceId": privateInstanceId})
 
 	msg := &Message{
-		URIs:              route.URIs,
-		Host:              host,
-		Port:              route.Port,
-		TLSPort:           route.TLSPort,
-		Tags:              route.Tags,
-		RouteServiceUrl:   route.RouteServiceUrl,
-		PrivateInstanceId: privateInstanceId,
+		URIs:                route.URIs,
+		Host:                host,
+		Port:                route.Port,
+		TLSPort:             route.TLSPort,
+		Tags:                route.Tags,
+		RouteServiceUrl:     route.RouteServiceUrl,
+		ServerCertDomainSAN: route.ServerCertDomainSAN,
+		PrivateInstanceId:   privateInstanceId,
 	}
 
 	json, err := json.Marshal(msg)

--- a/messagebus/messagebus.go
+++ b/messagebus/messagebus.go
@@ -30,7 +30,8 @@ type msgBus struct {
 type Message struct {
 	URIs              []string          `json:"uris"`
 	Host              string            `json:"host"`
-	Port              int               `json:"port"`
+	Port              *int              `json:"port,omitempty"`
+	TLSPort           *int              `json:"tls_port,omitempty"`
 	Tags              map[string]string `json:"tags"`
 	RouteServiceUrl   string            `json:"route_service_url,omitempty"`
 	PrivateInstanceId string            `json:"private_instance_id"`
@@ -101,6 +102,7 @@ func (m msgBus) SendMessage(subject string, host string, route config.Route, pri
 		URIs:              route.URIs,
 		Host:              host,
 		Port:              route.Port,
+		TLSPort:           route.TLSPort,
 		Tags:              route.Tags,
 		RouteServiceUrl:   route.RouteServiceUrl,
 		PrivateInstanceId: privateInstanceId,

--- a/messagebus/messagebus_test.go
+++ b/messagebus/messagebus_test.go
@@ -148,12 +148,13 @@ var _ = Describe("Messagebus test Suite", func() {
 			port := 12345
 
 			route = config.Route{
-				Name:            "some_name",
-				Port:            &port,
-				TLSPort:         &port,
-				URIs:            []string{"uri1", "uri2"},
-				RouteServiceUrl: "https://rs.example.com",
-				Tags:            map[string]string{"tag1": "val1", "tag2": "val2"},
+				Name:                "some_name",
+				Port:                &port,
+				TLSPort:             &port,
+				URIs:                []string{"uri1", "uri2"},
+				RouteServiceUrl:     "https://rs.example.com",
+				Tags:                map[string]string{"tag1": "val1", "tag2": "val2"},
+				ServerCertDomainSAN: "cf.cert.internal",
 			}
 		})
 
@@ -176,12 +177,13 @@ var _ = Describe("Messagebus test Suite", func() {
 			Eventually(registered, 2).Should(Receive(&receivedMessage))
 
 			expectedRegistryMessage := messagebus.Message{
-				URIs:            route.URIs,
-				Host:            host,
-				Port:            route.Port,
-				TLSPort:         route.TLSPort,
-				RouteServiceUrl: route.RouteServiceUrl,
-				Tags:            route.Tags,
+				URIs:                route.URIs,
+				Host:                host,
+				Port:                route.Port,
+				TLSPort:             route.TLSPort,
+				RouteServiceUrl:     route.RouteServiceUrl,
+				Tags:                route.Tags,
+				ServerCertDomainSAN: "cf.cert.internal",
 			}
 
 			var registryMessage messagebus.Message

--- a/messagebus/messagebus_test.go
+++ b/messagebus/messagebus_test.go
@@ -145,9 +145,12 @@ var _ = Describe("Messagebus test Suite", func() {
 			err := messageBus.Connect(messageBusServers)
 			Expect(err).ShouldNot(HaveOccurred())
 
+			port := 12345
+
 			route = config.Route{
 				Name:            "some_name",
-				Port:            12345,
+				Port:            &port,
+				TLSPort:         &port,
 				URIs:            []string{"uri1", "uri2"},
 				RouteServiceUrl: "https://rs.example.com",
 				Tags:            map[string]string{"tag1": "val1", "tag2": "val2"},
@@ -176,6 +179,7 @@ var _ = Describe("Messagebus test Suite", func() {
 				URIs:            route.URIs,
 				Host:            host,
 				Port:            route.Port,
+				TLSPort:         route.TLSPort,
 				RouteServiceUrl: route.RouteServiceUrl,
 				Tags:            route.Tags,
 			}

--- a/registrar/registrar_test.go
+++ b/registrar/registrar_test.go
@@ -72,12 +72,14 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 
 		signals = make(chan os.Signal, 1)
 		ready = make(chan struct{}, 1)
+		port := 8080
+		port2 := 8081
 
 		registrationInterval := 100 * time.Millisecond
 		rrConfig.Routes = []config.Route{
 			{
 				Name: "my route 1",
-				Port: 8080,
+				Port: &port,
 				URIs: []string{
 					"my uri 1.1",
 					"my uri 1.2",
@@ -89,8 +91,8 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 				RegistrationInterval: registrationInterval,
 			},
 			{
-				Name: "my route 2",
-				Port: 8081,
+				Name:    "my route 2",
+				TLSPort: &port2,
 				URIs: []string{
 					"my uri 2.1",
 					"my uri 2.2",

--- a/registrar/registrar_test.go
+++ b/registrar/registrar_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Registrar.RegisterRoutes", func() {
 					"tag2.2": "value2.2",
 				},
 				RegistrationInterval: registrationInterval,
+				ServerCertDomainSAN:  "my.internal.cert",
 			},
 		}
 


### PR DESCRIPTION
## What

As a followup to the changes [proposed by GOVAU](https://github.com/cloudfoundry/route-registrar/pull/18), we'd like to implement a `server_cert_domain_san` property to support the one from the gorouter.

We've upgraded gorouter and route-registrar to use TLS for the UAA routes, gorouter has been failing to connect because it couldn't validate the IP it’s connecting to against the subjectAltNames in the certificate from Nginx on uaa/*. At the moment that cert is issued for `uaa.service.cf.internal` which is provided by Consul service discovery and we needed to make sure Gorouter knows about it.

## How to review

- Code sanity
- To be deployed and tested with the alphagov/paas-routing-release#1

## Who can review

Neither @bandesz, @dcarley nor myself.